### PR TITLE
Do not reset turning if opposite direction is down

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -245,9 +245,9 @@ function love.keyreleased(key, scancode)
     playerLocal:endAccelerating()
   elseif key == "s" then
     playerLocal:endReversing()
-  elseif key == "a" then
+  elseif key == "a" and not love.keyboard.isDown("d") then
     playerLocal:endTurningLeft()
-  elseif key == "d" then
+  elseif key == "d" and not love.keyboard.isDown("a") then
     playerLocal:endTurningRight()
   elseif key == "space" then
     playerLocal:endBraking()


### PR DESCRIPTION
When handling keyreleased events, only fire the endTurning events when
the opposite direction key is not currently being held down.

This resolves the issue where the car is "stuck" and unable to turn due
to a endTurning event resetting the angle/torque to zero while the
opposite direction is still being held.